### PR TITLE
producer.Close() no longer accepts input parameters

### DIFF
--- a/log_emitters.go
+++ b/log_emitters.go
@@ -134,7 +134,7 @@ func (k *KafkaLogEmitter) Emit(logLine *avro.LogLine) {
 
 // Close closes the underlying producer. The KafkaLogEmitter won't be usable anymore after call to this.
 func (k *KafkaLogEmitter) Close() {
-	k.producer.Close(k.config.ProducerCloseTimeout)
+	k.producer.Close()
 }
 
 // Trace formats a given message according to given params to log with level Trace and produces to a given Kafka topic.

--- a/testing_utils.go
+++ b/testing_utils.go
@@ -151,7 +151,7 @@ func produceN(t *testing.T, n int, topic string, brokerAddr string) {
 	producerConfig := producer.NewProducerConfig()
 
 	p := producer.NewKafkaProducer(producerConfig, producer.ByteSerializer, producer.StringSerializer, connector)
-	defer p.Close(time.Second)
+	defer p.Close()
 
 	metadatas := make([]<-chan *producer.RecordMetadata, n)
 
@@ -175,7 +175,7 @@ func produceNToTopicPartition(t *testing.T, n int, topic string, partition int, 
 	producerConfig.Partitioner = producer.NewManualPartitioner()
 
 	p := producer.NewKafkaProducer(producerConfig, producer.ByteSerializer, producer.StringSerializer, connector)
-	defer p.Close(time.Second)
+	defer p.Close()
 
 	metadatas := make([]<-chan *producer.RecordMetadata, n)
 


### PR DESCRIPTION
Fixes https://github.com/elodina/go_kafka_client/issues/194